### PR TITLE
changed theme PATH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A theme of Hatsune Miku for Grub!
 
 1. Download & Unzip
 
-2. Copy `HatsuneMiku/[preffered size]-HatsuneMiku` into grub themes directory:
+2. Copy `[preffered size]-HatsuneMiku` into grub themes directory:
 
 ```bash
-sudo cp -r HatsuneMiku/4k-HatsuneMiku /usr/share/grub/themes
+sudo cp -r 4k-HatsuneMiku /usr/share/grub/themes
 ```
 
 3. Edit `grub` file:


### PR DESCRIPTION
The README directs users to copy the theme from HatsuneMiku/[preferred size] however there is no directory "HatsuneMiku" and instead the themes are in the parent directory itself.

I have changed HatsuneMiku/[preferred theme] to [preferred theme]

(first PR sorry if iv made any dumb mistakes, lovely theme btw)